### PR TITLE
fix(auth): correct token decoding for user id and role fields

### DIFF
--- a/src/utils/tokenUtils.ts
+++ b/src/utils/tokenUtils.ts
@@ -10,9 +10,9 @@ export function decodeToken(token: string): IUser {
   const payload = JSON.parse(atob(parts[1] as string))
 
   return {
-    id: payload.id,
+    id: payload.sub,
     name: payload.name,
     email: payload.email,
-    role: payload.role,
+    role: payload['http://schemas.microsoft.com/ws/2008/06/identity/claims/role'],
   }
 }


### PR DESCRIPTION
The token decoding function was incorrectly mapping the user id and role fields from the JWT payload. The changes update the field mappings to use the correct JWT claim names:

- Changed `payload.id` to `payload.sub` for user id
- Changed `payload.role` to `payload['http://schemas.microsoft.com/ws/2008/06/identity/claims/role']` for role

This ensures proper user data extraction from the token payload.